### PR TITLE
Fix module imports and data paths after directory restructure

### DIFF
--- a/dev_model_training/train_meta_model.py
+++ b/dev_model_training/train_meta_model.py
@@ -3,10 +3,21 @@ import numpy as np
 import xgboost as xgb
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
-from sklearn.metrics import accuracy_score
 import json
+from pathlib import Path
 
-df = pd.read_csv("signals.csv")
+DATA_PATH = Path("prod_data/signals.csv")
+MODEL_DIR = Path("prod_models")
+META_MODEL_PATH = MODEL_DIR / "meta_model.json"
+META_FEATURES_PATH = MODEL_DIR / "meta_features.json"
+META_LABELS_PATH = MODEL_DIR / "meta_labels.json"
+
+if not DATA_PATH.exists():
+    raise FileNotFoundError(f"Meta training data not found at {DATA_PATH}")
+
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+df = pd.read_csv(DATA_PATH)
 df = df.dropna()
 
 df["label"] = np.random.choice(["enter_long","enter_short","exit_long","exit_short","none"], size=len(df))
@@ -22,12 +33,10 @@ X_train, X_test, y_train, y_test = train_test_split(X, y_encoded, test_size=0.2,
 meta_model = xgb.XGBClassifier()
 meta_model.fit(X_train, y_train)
 
-preds = meta_model.predict(X_test)
+meta_model.save_model(META_MODEL_PATH)
 
-meta_model.save_model("meta_model.json")
-
-with open("meta_features.json", "w") as f:
+with META_FEATURES_PATH.open("w") as f:
     json.dump(list(X.columns), f)
 
-with open("meta_labels.json", "w") as f:
+with META_LABELS_PATH.open("w") as f:
     json.dump(list(le.classes_), f)

--- a/dev_model_training/train_solusd_lgb.py
+++ b/dev_model_training/train_solusd_lgb.py
@@ -2,12 +2,35 @@ import pandas as pd
 import lightgbm as lgb
 from sklearn.model_selection import train_test_split
 import json
+from pathlib import Path
 
-df = pd.read_parquet("ohlcv.parquet")
+IGNORED_COLUMNS = {
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "vwap",
+    "volume",
+    "count",
+    "Target",
+}
+
+DATA_PATH = Path("prod_data/solusd_data_feats.parquet")
+MODEL_DIR = Path("prod_models")
+LGB_MODEL_PATH = MODEL_DIR / "lgb_model.txt"
+LGB_FEATURES_PATH = MODEL_DIR / "features_lgb.json"
+
+if not DATA_PATH.exists():
+    raise FileNotFoundError(f"Training data not found at {DATA_PATH}")
+
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+df = pd.read_parquet(DATA_PATH)
 df["Target"] = df["close"].shift(-1)
 df = df.dropna()
 
-feature_cols = [c for c in df.columns if c not in ["timestamp", "open", "high", "low", "close", "vwap", "volume", "count", "Target"]]
+feature_cols = [c for c in df.columns if c not in IGNORED_COLUMNS]
 X = df[feature_cols]
 y = df["Target"]
 
@@ -17,8 +40,7 @@ test_data = lgb.Dataset(X_test, label=y_test, reference=train_data)
 
 params = {"objective": "regression", "metric": "rmse"}
 model = lgb.train(params, train_data)
-preds = model.predict(X_test)
-model.save_model("lgb_model.txt")
+model.save_model(LGB_MODEL_PATH)
 
-with open("features_lgb.json", "w") as f:
+with LGB_FEATURES_PATH.open("w") as f:
     json.dump(feature_cols, f)

--- a/dev_model_training/train_solusd_xgb.py
+++ b/dev_model_training/train_solusd_xgb.py
@@ -2,20 +2,42 @@ import pandas as pd
 import xgboost as xgb
 from sklearn.model_selection import train_test_split
 import json
+from pathlib import Path
 
-df = pd.read_parquet("ohlcv.parquet")
+IGNORED_COLUMNS = {
+    "timestamp",
+    "open",
+    "high",
+    "low",
+    "close",
+    "vwap",
+    "volume",
+    "count",
+    "Target",
+}
+
+DATA_PATH = Path("prod_data/solusd_data_feats.parquet")
+MODEL_DIR = Path("prod_models")
+XGB_MODEL_PATH = MODEL_DIR / "xgb_model.json"
+XGB_FEATURES_PATH = MODEL_DIR / "features.json"
+
+if not DATA_PATH.exists():
+    raise FileNotFoundError(f"Training data not found at {DATA_PATH}")
+
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+df = pd.read_parquet(DATA_PATH)
 df["Target"] = df["close"].shift(-1)
 df = df.dropna()
 
-feature_cols = [c for c in df.columns if c not in ["timestamp", "open", "high", "low", "close", "vwap", "volume", "count", "Target"]]
+feature_cols = [c for c in df.columns if c not in IGNORED_COLUMNS]
 X = df[feature_cols]
 y = df["Target"]
 
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, shuffle=False)
 model = xgb.XGBRegressor()
 model.fit(X_train, y_train)
-preds = model.predict(X_test)
-model.save_model("xgb_model.json")
+model.save_model(XGB_MODEL_PATH)
 
-with open("features.json", "w") as f:
+with XGB_FEATURES_PATH.open("w") as f:
     json.dump(feature_cols, f)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import subprocess
 import time
-import signal
 import sys
 import logging
 
@@ -17,11 +16,13 @@ logging.basicConfig(
 
 processes = []
 
-def start_process(script):
-    p = subprocess.Popen(["python", script])
+def start_process(module: str) -> None:
+    """Start a Python module in a new subprocess."""
+
+    p = subprocess.Popen([sys.executable, "-m", module])
     processes.append(p)
-    logging.info(f"Started {script} (pid {p.pid})")
-    print(f"Started {script} (pid {p.pid})")
+    logging.info(f"Started {module} (pid {p.pid})")
+    print(f"Started {module} (pid {p.pid})")
 
 def stop_all():
     print("\nStopping all processes...")
@@ -36,15 +37,15 @@ def stop_all():
 
 if __name__ == "__main__":
     try:
-        start_process("data_manager.py")
+        start_process("prod_workflow.data_manager")
         time.sleep(2)
-        start_process("inference_loop.py")
+        start_process("prod_workflow.inference_loop")
         time.sleep(2)
-        start_process("meta_inference_loop.py")
+        start_process("prod_workflow.meta_inference_loop")
         time.sleep(2)
-        start_process("brain.py")
+        start_process("prod_workflow.brain")
         time.sleep(2)
-        # start_process("broker.py")
+        # start_process("prod_workflow.broker")
 
         logging.info("All processes started successfully.")
 

--- a/prod_workflow/data_manager.py
+++ b/prod_workflow/data_manager.py
@@ -3,8 +3,8 @@ import time
 import os
 from datetime import datetime, UTC
 
-from fetch_ohlc import fetch
-from feature_creation import create_features
+from prod_workflow.fetch_ohlc import fetch
+from Feature_creation.feature_creation import create_features
 from _utils.config import get_env, get_int_env
 
 FILE_PATH = get_env("DATA_PATH")


### PR DESCRIPTION
## Summary
- update the main controller to launch workflow modules via their package paths
- fix workflow imports after moving fetch and feature creation modules into packages
- point the training scripts at the new prod_data and prod_models locations and ensure their outputs land in the correct directories

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f445834c0883319db5246361130a0a